### PR TITLE
Add support for inflateSync function

### DIFF
--- a/zlib/Inflater.rbbas
+++ b/zlib/Inflater.rbbas
@@ -149,17 +149,17 @@ Inherits FlateEngine
 		  
 		  If Not IsOpen Then Return False
 		  
-		  Dim outbuff As New MemoryBlock(CHUNK_SIZE)
 		  Dim count As Integer
 		  Do
-		    Dim chunk As MemoryBlock = ReadFrom.Read(CHUNK_SIZE)
-		    If chunk.Size = 0 Then Return False
+		    Dim sz As Integer
+		    Dim chunk As MemoryBlock = ReadFrom.Read(2)
+		    If chunk.Size <> 2 Then Return False
 		    zstruct.avail_in = chunk.Size
 		    zstruct.next_in = chunk
 		    count = count + chunk.Size
 		    
-		    zstruct.next_out = outbuff
-		    zstruct.avail_out = outbuff.Size
+		    zstruct.next_out = Nil
+		    zstruct.avail_out = 0
 		    mLastError = inflateSync(zstruct)
 		  Loop Until mLastError <> Z_DATA_ERROR Or ReadFrom.EOF Or (MaxCount > -1 And count >= MaxCount)
 		  

--- a/zlib/ZStream.rbbas
+++ b/zlib/ZStream.rbbas
@@ -349,9 +349,14 @@ Implements zlib.CompressedStream
 		  ' Reads compressed bytes from the input stream until a possible deflate stream is detected.
 		  
 		  If mInflater = Nil Or Not mSource IsA BinaryStream Then Raise New IOException
-		  If Not mInflater.SyncToNextFlush(mSource, MaxCount) Then Return False
-		  BinaryStream(mSource).Position = Inflater.Total_In
-		  Return True
+		  Dim pos As UInt64 = BinaryStream(mSource).Position
+		  If mInflater.SyncToNextFlush(mSource, MaxCount) Then
+		    BinaryStream(mSource).Position = Inflater.Total_In
+		    Return True
+		  Else
+		    BinaryStream(mSource).Position = pos
+		    Return False
+		  End If
 		  
 		End Function
 	#tag EndMethod

--- a/zlib/ZStream.rbbas
+++ b/zlib/ZStream.rbbas
@@ -348,18 +348,9 @@ Implements zlib.CompressedStream
 		Function SyncToNextFlush(MaxCount As Integer = -1) As Boolean
 		  ' Reads compressed bytes from the input stream until a possible deflate stream is detected.
 		  
-		  If mInflater = Nil Or Not mSource IsA BinaryStream Or mBufferedReading Then Raise New IOException
-		  Dim seeker As New Inflater
-		  Dim bs As BinaryStream = BinaryStream(mSource)
-		  Dim currentpos As UInt64 = bs.Position
-		  If seeker.SyncToNextFlush(mSource, MaxCount) Then
-		    bs.Position = currentpos + seeker.Total_In
-		    Return True
-		  Else
-		    bs.Position = currentpos
-		    Return False
-		  End If
-		  
+		  If mInflater = Nil Then Raise New IOException
+		  Dim currentpos As UInt32 = mInflater.Total_In
+		  Return mInflater.SyncToNextFlush(mSource, MaxCount)
 		End Function
 	#tag EndMethod
 

--- a/zlib/ZStream.rbbas
+++ b/zlib/ZStream.rbbas
@@ -348,9 +348,11 @@ Implements zlib.CompressedStream
 		Function SyncToNextFlush(MaxCount As Integer = -1) As Boolean
 		  ' Reads compressed bytes from the input stream until a possible deflate stream is detected.
 		  
-		  If mInflater = Nil Then Raise New IOException
-		  Dim currentpos As UInt32 = mInflater.Total_In
-		  Return mInflater.SyncToNextFlush(mSource, MaxCount)
+		  If mInflater = Nil Or Not mSource IsA BinaryStream Then Raise New IOException
+		  If Not mInflater.SyncToNextFlush(mSource, MaxCount) Then Return False
+		  BinaryStream(mSource).Position = Inflater.Total_In
+		  Return True
+		  
 		End Function
 	#tag EndMethod
 

--- a/zlib/ZStream.rbbas
+++ b/zlib/ZStream.rbbas
@@ -345,6 +345,25 @@ Implements zlib.CompressedStream
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
+		Function SyncToNextFlush(MaxCount As Integer = -1) As Boolean
+		  ' Reads compressed bytes from the input stream until a possible deflate stream is detected.
+		  
+		  If mInflater = Nil Or Not mSource IsA BinaryStream Or mBufferedReading Then Raise New IOException
+		  Dim seeker As New Inflater
+		  Dim bs As BinaryStream = BinaryStream(mSource)
+		  Dim currentpos As UInt64 = bs.Position
+		  If seeker.SyncToNextFlush(mSource, MaxCount) Then
+		    bs.Position = currentpos + seeker.Total_In
+		    Return True
+		  Else
+		    bs.Position = currentpos
+		    Return False
+		  End If
+		  
+		End Function
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
 		Sub Write(Data As String)
 		  // Part of the Writeable interface.
 		  ' Write Data to the compressed stream. 


### PR DESCRIPTION
The `inflateSync` function attempts to locate a flush point in the decompression stream. A "flush point" is created when `ZStream.Flush` is called with `Z_SYNC_FLUSH` as the `Flushing` parameter.