### PR TITLE
Replace constants with enums

### DIFF
--- a/zlib/CompressedStream.rbbas
+++ b/zlib/CompressedStream.rbbas
@@ -8,7 +8,7 @@ Implements Readable,Writeable
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub Flush(Flushing As Integer)
+		Sub Flush(Flushing As zlib.FlushMode)
 		  
 		End Sub
 	#tag EndMethod

--- a/zlib/Deflater.rbbas
+++ b/zlib/Deflater.rbbas
@@ -10,7 +10,7 @@ Inherits FlateEngine
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub Constructor(CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Encoding As Integer = zlib.DEFLATE_ENCODING, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL)
+		Sub Constructor(CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Encoding As zlib.Encoding = zlib.Encoding.Deflate, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL)
 		  ' Construct a new Deflater instance using the specified compression options.
 		  ' If the deflate engine could not be initialized an exception will be raised.
 		  
@@ -18,7 +18,7 @@ Inherits FlateEngine
 		  // Constructor() -- From zlib.FlateEngine
 		  Super.Constructor()
 		  
-		  If CompressionStrategy <> Strategies.Default Or Encoding <> DEFLATE_ENCODING Or MemoryLevel <> DEFAULT_MEM_LVL Then
+		  If CompressionStrategy <> Strategies.Default Or Encoding <> zlib.Encoding.Deflate Or MemoryLevel <> DEFAULT_MEM_LVL Then
 		    ' Open the compressed stream using custom options
 		    mLastError = deflateInit2_(zstruct, CompressionLevel, Z_DEFLATED, Encoding, MemoryLevel, CompressionStrategy, "1.2.8" + Chr(0), zstruct.Size)
 		    
@@ -230,7 +230,7 @@ Inherits FlateEngine
 			  Return mEncoding
 			End Get
 		#tag EndGetter
-		Encoding As Integer
+		Encoding As zlib.Encoding
 	#tag EndComputedProperty
 
 	#tag ComputedProperty, Flags = &h0
@@ -259,7 +259,7 @@ Inherits FlateEngine
 	#tag EndComputedProperty
 
 	#tag Property, Flags = &h1
-		Protected mEncoding As Integer
+		Protected mEncoding As zlib.Encoding
 	#tag EndProperty
 
 	#tag Property, Flags = &h1

--- a/zlib/Deflater.rbbas
+++ b/zlib/Deflater.rbbas
@@ -195,10 +195,10 @@ Inherits FlateEngine
 	#tag ComputedProperty, Flags = &h0
 		#tag Getter
 			Get
-			  Return zstruct.data_type
+			  Return zlib.DataType(zstruct.data_type)
 			End Get
 		#tag EndGetter
-		DataType As UInt32
+		DataType As zlib.DataType
 	#tag EndComputedProperty
 
 	#tag ComputedProperty, Flags = &h0

--- a/zlib/Deflater.rbbas
+++ b/zlib/Deflater.rbbas
@@ -10,7 +10,7 @@ Inherits FlateEngine
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub Constructor(CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As Integer = zlib.Z_DEFAULT_STRATEGY, Encoding As Integer = zlib.DEFLATE_ENCODING, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL)
+		Sub Constructor(CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Encoding As Integer = zlib.DEFLATE_ENCODING, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL)
 		  ' Construct a new Deflater instance using the specified compression options.
 		  ' If the deflate engine could not be initialized an exception will be raised.
 		  
@@ -18,7 +18,7 @@ Inherits FlateEngine
 		  // Constructor() -- From zlib.FlateEngine
 		  Super.Constructor()
 		  
-		  If CompressionStrategy <> Z_DEFAULT_STRATEGY Or Encoding <> DEFLATE_ENCODING Or MemoryLevel <> DEFAULT_MEM_LVL Then
+		  If CompressionStrategy <> Strategies.Default Or Encoding <> DEFLATE_ENCODING Or MemoryLevel <> DEFAULT_MEM_LVL Then
 		    ' Open the compressed stream using custom options
 		    mLastError = deflateInit2_(zstruct, CompressionLevel, Z_DEFLATED, Encoding, MemoryLevel, CompressionStrategy, "1.2.8" + Chr(0), zstruct.Size)
 		    
@@ -267,7 +267,7 @@ Inherits FlateEngine
 	#tag EndProperty
 
 	#tag Property, Flags = &h1
-		Protected mStrategy As Integer = Z_DEFAULT_STRATEGY
+		Protected mStrategy As zlib.Strategies = zlib.Strategies.Default
 	#tag EndProperty
 
 	#tag ComputedProperty, Flags = &h0
@@ -290,7 +290,7 @@ Inherits FlateEngine
 			  
 			End Set
 		#tag EndSetter
-		Strategy As Integer
+		Strategy As zlib.Strategies
 	#tag EndComputedProperty
 
 

--- a/zlib/Deflater.rbbas
+++ b/zlib/Deflater.rbbas
@@ -53,7 +53,7 @@ Inherits FlateEngine
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Function Deflate(Data As MemoryBlock, Flushing As Integer = zlib.Z_NO_FLUSH) As MemoryBlock
+		Function Deflate(Data As MemoryBlock, Flushing As zlib.FlushMode = zlib.FlushMode.None) As MemoryBlock
 		  ' Compresses Data and returns it as a new MemoryBlock, or Nil on error.
 		  ' Check LastError for details if there was an error.
 		  
@@ -69,7 +69,7 @@ Inherits FlateEngine
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Function Deflate(ReadFrom As Readable, WriteTo As Writeable, Flushing As Integer = zlib.Z_NO_FLUSH, ReadCount As Integer = - 1) As Boolean
+		Function Deflate(ReadFrom As Readable, WriteTo As Writeable, Flushing As zlib.FlushMode = zlib.FlushMode.None, ReadCount As Integer = - 1) As Boolean
 		  ' Reads uncompressed bytes from ReadFrom and writes all compressed output to WriteTo. If
 		  ' ReadCount is specified then exactly ReadCount uncompressed bytes are read; otherwise
 		  ' uncompressed bytes will continue to be read until ReadFrom.EOF. If ReadFrom represents 
@@ -114,7 +114,7 @@ Inherits FlateEngine
 		    
 		  Loop Until (ReadCount > -1 And count >= ReadCount) Or ReadFrom = Nil Or ReadFrom.EOF
 		  
-		  If Flushing = Z_FINISH And mLastError <> Z_STREAM_END Then Raise New zlibException(mLastError)
+		  If Flushing = FlushMode.Finish And mLastError <> Z_STREAM_END Then Raise New zlibException(mLastError)
 		  Return zstruct.avail_in = 0 And (mLastError = Z_OK Or mLastError = Z_STREAM_END)
 		  
 		  

--- a/zlib/Deflater.rbbas
+++ b/zlib/Deflater.rbbas
@@ -10,7 +10,7 @@ Inherits FlateEngine
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub Constructor(CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Encoding As zlib.Encoding = zlib.Encoding.Deflate, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL)
+		Sub Constructor(CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Encoding As zlib.Encoding = zlib.Encoding.Deflate, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL)
 		  ' Construct a new Deflater instance using the specified compression options.
 		  ' If the deflate engine could not be initialized an exception will be raised.
 		  

--- a/zlib/GZStream.rbbas
+++ b/zlib/GZStream.rbbas
@@ -63,15 +63,12 @@ Implements zlib.CompressedStream
 	#tag Method, Flags = &h21
 		Private Sub Flush() Implements Writeable.Flush
 		  // Part of the Writeable interface.
-		  ' Z_PARTIAL_FLUSH: All pending output is flushed to the output buffer, but the output is not aligned to a byte boundary.
-		  ' This completes the current deflate block and follows it with an empty fixed codes block that is 10 bits long.
-		  
-		  Me.Flush(Z_SYNC_FLUSH)
+		  Me.Flush(FlushMode.Sync)
 		End Sub
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub Flush(Flushing As Integer) Implements zlib.CompressedStream.Flush
+		Sub Flush(Flushing As zlib.FlushMode) Implements zlib.CompressedStream.Flush
 		  // Part of the zlib.CompressedStream interface.
 		  If Not mIsWriteable Then Raise New IOException ' opened for reading!
 		  If gzFile = Nil Then Raise New NilObjectException

--- a/zlib/GZStream.rbbas
+++ b/zlib/GZStream.rbbas
@@ -28,7 +28,7 @@ Implements zlib.CompressedStream
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function Create(OutputFile As FolderItem, Append As Boolean = False, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As Integer = zlib.Z_DEFAULT_STRATEGY) As zlib.GZStream
+		 Shared Function Create(OutputFile As FolderItem, Append As Boolean = False, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default) As zlib.GZStream
 		  ' Creates an empty gzip stream, or opens an existing stream for appending
 		  If OutputFile = Nil Or OutputFile.Directory Then Raise New IOException
 		  Dim mode As String = "wb"
@@ -300,7 +300,7 @@ Implements zlib.CompressedStream
 	#tag EndProperty
 
 	#tag Property, Flags = &h21
-		Private mStrategy As Integer = Z_DEFAULT_STRATEGY
+		Private mStrategy As zlib.Strategies = zlib.Strategies.Default
 	#tag EndProperty
 
 	#tag ComputedProperty, Flags = &h0
@@ -340,7 +340,7 @@ Implements zlib.CompressedStream
 			  
 			End Set
 		#tag EndSetter
-		Strategy As Integer
+		Strategy As zlib.Strategies
 	#tag EndComputedProperty
 
 

--- a/zlib/Inflater.rbbas
+++ b/zlib/Inflater.rbbas
@@ -172,16 +172,6 @@ Inherits FlateEngine
 	#tag ComputedProperty, Flags = &h0
 		#tag Getter
 			Get
-			  ' Returns the decoding state
-			  Return zlib.DataType(zstruct.data_type)
-			End Get
-		#tag EndGetter
-		DataType As zlib.DataType
-	#tag EndComputedProperty
-
-	#tag ComputedProperty, Flags = &h0
-		#tag Getter
-			Get
 			  ' Returns the sliding dictionary being maintained by inflate()
 			  
 			  If Not IsOpen Then Return Nil
@@ -245,6 +235,16 @@ Inherits FlateEngine
 	#tag Property, Flags = &h21
 		Private mGZHeader As gz_headerp
 	#tag EndProperty
+
+	#tag ComputedProperty, Flags = &h0
+		#tag Getter
+			Get
+			  ' Returns the decoding state
+			  Return zstruct.data_type
+			End Get
+		#tag EndGetter
+		State As UInt32
+	#tag EndComputedProperty
 
 
 	#tag ViewBehavior

--- a/zlib/Inflater.rbbas
+++ b/zlib/Inflater.rbbas
@@ -92,7 +92,7 @@ Inherits FlateEngine
 		      ' provide more output space
 		      zstruct.next_out = outbuff
 		      zstruct.avail_out = outbuff.Size
-		      mLastError = inflate(zstruct, Z_NO_FLUSH)
+		      mLastError = inflate(zstruct, FlushMode.None)
 		      ' consume any output
 		      Dim have As UInt32 = CHUNK_SIZE - zstruct.avail_out
 		      If have > 0 Then

--- a/zlib/Inflater.rbbas
+++ b/zlib/Inflater.rbbas
@@ -2,20 +2,20 @@
 Protected Class Inflater
 Inherits FlateEngine
 	#tag Method, Flags = &h0
-		Sub Constructor(Encoding As Integer = zlib.DEFLATE_ENCODING)
+		Sub Constructor(Encoding As zlib.Encoding = zlib.Encoding.Deflate)
 		  ' Construct a new Inflater instance using the specified Encoding. Encoding control,
-		  ' among other things, the type of compression being used. (For GZip pass GZIP_ENCODING)
+		  ' among other things, the type of compression being used. (For GZip pass zlib.Encoding.GZip)
 		  ' If the inflate engine could not be initialized an exception will be raised.
 		  
 		  // Calling the overridden superclass constructor.
 		  // Constructor() -- From zlib.FlateEngine
 		  Super.Constructor()
 		  
-		  If Encoding = DEFLATE_ENCODING Then
+		  If Encoding = zlib.Encoding.Deflate Then
 		    mLastError = inflateInit_(zstruct, "1.2.8" + Chr(0), zstruct.Size)
 		  Else
 		    mLastError = inflateInit2_(zstruct, Encoding, "1.2.8" + Chr(0), zstruct.Size)
-		    If mLastError = Z_OK And Encoding >= GZIP_ENCODING Then mLastError = inflateGetHeader(zstruct, mGZHeader)
+		    If mLastError = Z_OK And Integer(Encoding) >= Integer(zlib.Encoding.GZip) Then mLastError = inflateGetHeader(zstruct, mGZHeader)
 		  End If
 		  If mLastError <> Z_OK Then Raise New zlibException(mLastError)
 		  mEncoding = Encoding
@@ -127,13 +127,13 @@ Inherits FlateEngine
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub Reset(Encoding As Integer = 0)
+		Sub Reset(Encoding As zlib.Encoding = zlib.Encoding.Detect)
 		  ' Reinitializes the decompressor but does not free and reallocate all the internal decompression state.
 		  ' The stream will keep the attributes that may have been set by the constructor.
 		  
 		  If Not IsOpen Then Return
 		  If mGZHeader.Done = 1 Then mGZHeader.Done = 0
-		  If Encoding = 0 Then
+		  If Encoding = zlib.Encoding.Detect Then
 		    mLastError = inflateReset(zstruct)
 		  Else
 		    mLastError = inflateReset2(zstruct, Encoding)
@@ -203,7 +203,7 @@ Inherits FlateEngine
 			  Return mEncoding
 			End Get
 		#tag EndGetter
-		Encoding As Integer
+		Encoding As zlib.Encoding
 	#tag EndComputedProperty
 
 	#tag ComputedProperty, Flags = &h0
@@ -229,7 +229,7 @@ Inherits FlateEngine
 	#tag EndProperty
 
 	#tag Property, Flags = &h1
-		Protected mEncoding As Integer
+		Protected mEncoding As zlib.Encoding
 	#tag EndProperty
 
 	#tag Property, Flags = &h21

--- a/zlib/Inflater.rbbas
+++ b/zlib/Inflater.rbbas
@@ -173,10 +173,10 @@ Inherits FlateEngine
 		#tag Getter
 			Get
 			  ' Returns the decoding state
-			  Return zstruct.data_type
+			  Return zlib.DataType(zstruct.data_type)
 			End Get
 		#tag EndGetter
-		DataType As UInt32
+		DataType As zlib.DataType
 	#tag EndComputedProperty
 
 	#tag ComputedProperty, Flags = &h0

--- a/zlib/ZStream.rbbas
+++ b/zlib/ZStream.rbbas
@@ -24,7 +24,7 @@ Implements zlib.CompressedStream
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub Constructor(Source As BinaryStream, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As Integer = zlib.Z_DEFAULT_STRATEGY, Encoding As Integer = zlib.Z_DETECT, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL)
+		Sub Constructor(Source As BinaryStream, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Encoding As Integer = zlib.Z_DETECT, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL)
 		  ' Constructs a ZStream from the Source BinaryStream. If the Source's current position is equal
 		  ' to its length then compressed output will be appended, otherwise the Source will be used as 
 		  ' input to be decompressed.
@@ -49,7 +49,7 @@ Implements zlib.CompressedStream
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub Constructor(Source As MemoryBlock, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As Integer = zlib.Z_DEFAULT_STRATEGY, Encoding As Integer = zlib.Z_DETECT, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL)
+		Sub Constructor(Source As MemoryBlock, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Encoding As Integer = zlib.Z_DETECT, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL)
 		  ' Constructs a ZStream from the Source MemoryBlock. If the Source's size is zero then
 		  ' compressed output will be appended, otherwise the Source will be used as input
 		  ' to be decompressed.
@@ -83,7 +83,7 @@ Implements zlib.CompressedStream
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function Create(OutputStream As FolderItem, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As Integer = zlib.Z_DEFAULT_STRATEGY, Overwrite As Boolean = False, Encoding As Integer = zlib.DEFLATE_ENCODING, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL) As zlib.ZStream
+		 Shared Function Create(OutputStream As FolderItem, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Overwrite As Boolean = False, Encoding As Integer = zlib.DEFLATE_ENCODING, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL) As zlib.ZStream
 		  ' Create a compression stream where compressed output is written to the OutputStream file.
 		  
 		  Return Create(BinaryStream.Create(OutputStream, Overwrite), CompressionLevel, CompressionStrategy, Encoding, MemoryLevel)
@@ -91,7 +91,7 @@ Implements zlib.CompressedStream
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function Create(OutputStream As Writeable, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As Integer = zlib.Z_DEFAULT_STRATEGY, Encoding As Integer = zlib.DEFLATE_ENCODING, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL) As zlib.ZStream
+		 Shared Function Create(OutputStream As Writeable, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Encoding As Integer = zlib.DEFLATE_ENCODING, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL) As zlib.ZStream
 		  ' Create a compression stream where compressed output is written to the OutputStream object.
 		  
 		  Return New ZStream(New Deflater(CompressionLevel, CompressionStrategy, Encoding, MemoryLevel), OutputStream)
@@ -100,7 +100,7 @@ Implements zlib.CompressedStream
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function CreatePipe(InputStream As Readable, OutputStream As Writeable, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As Integer = zlib.Z_DEFAULT_STRATEGY, Encoding As Integer = zlib.DEFLATE_ENCODING, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL) As zlib.ZStream
+		 Shared Function CreatePipe(InputStream As Readable, OutputStream As Writeable, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Encoding As Integer = zlib.DEFLATE_ENCODING, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL) As zlib.ZStream
 		  ' Create a compressed stream from two endpoints. Writing to the stream writes compressed bytes to
 		  ' the OutputStream object; reading from the stream decompresses bytes from the InputStream object.
 		  
@@ -532,7 +532,7 @@ Implements zlib.CompressedStream
 			  If mDeflater <> Nil Then mDeflater.Strategy = value
 			End Set
 		#tag EndSetter
-		Strategy As Integer
+		Strategy As zlib.Strategies
 	#tag EndComputedProperty
 
 	#tag ComputedProperty, Flags = &h0

--- a/zlib/ZStream.rbbas
+++ b/zlib/ZStream.rbbas
@@ -24,7 +24,7 @@ Implements zlib.CompressedStream
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub Constructor(Source As BinaryStream, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Encoding As Integer = zlib.Z_DETECT, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL)
+		Sub Constructor(Source As BinaryStream, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Encoding As zlib.Encoding = zlib.Encoding.Detect, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL)
 		  ' Constructs a ZStream from the Source BinaryStream. If the Source's current position is equal
 		  ' to its length then compressed output will be appended, otherwise the Source will be used as 
 		  ' input to be decompressed.

--- a/zlib/ZStream.rbbas
+++ b/zlib/ZStream.rbbas
@@ -30,17 +30,17 @@ Implements zlib.CompressedStream
 		  ' input to be decompressed.
 		  
 		  If Source.Length = Source.Position Then 'compress into Source
-		    If Encoding = Z_DETECT Then Encoding = DEFLATE_ENCODING
+		    If Encoding = zlib.Encoding.Detect Then Encoding = zlib.Encoding.Deflate
 		    Me.Constructor(New Deflater(CompressionLevel, CompressionStrategy, Encoding, MemoryLevel), Source)
 		  Else ' decompress from Source
-		    If Encoding = Z_DETECT Then
+		    If Encoding = zlib.Encoding.Detect Then
 		      Select Case True
 		      Case Source.IsDeflated
-		        Encoding = DEFLATE_ENCODING
+		        Encoding = zlib.Encoding.Deflate
 		      Case Source.IsGZipped
-		        Encoding = GZIP_ENCODING
+		        Encoding = zlib.Encoding.GZip
 		      Else
-		        Encoding = RAW_ENCODING
+		        Encoding = zlib.Encoding.Raw
 		      End Select
 		    End If
 		    Me.Constructor(New Inflater(Encoding), Source)
@@ -49,7 +49,7 @@ Implements zlib.CompressedStream
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub Constructor(Source As MemoryBlock, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Encoding As Integer = zlib.Z_DETECT, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL)
+		Sub Constructor(Source As MemoryBlock, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Encoding As zlib.Encoding = zlib.Encoding.Detect, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL)
 		  ' Constructs a ZStream from the Source MemoryBlock. If the Source's size is zero then
 		  ' compressed output will be appended, otherwise the Source will be used as input
 		  ' to be decompressed.
@@ -83,7 +83,7 @@ Implements zlib.CompressedStream
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function Create(OutputStream As FolderItem, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Overwrite As Boolean = False, Encoding As Integer = zlib.DEFLATE_ENCODING, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL) As zlib.ZStream
+		 Shared Function Create(OutputStream As FolderItem, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Overwrite As Boolean = False, Encoding As zlib.Encoding = zlib.Encoding.Deflate, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL) As zlib.ZStream
 		  ' Create a compression stream where compressed output is written to the OutputStream file.
 		  
 		  Return Create(BinaryStream.Create(OutputStream, Overwrite), CompressionLevel, CompressionStrategy, Encoding, MemoryLevel)
@@ -91,7 +91,7 @@ Implements zlib.CompressedStream
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function Create(OutputStream As Writeable, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Encoding As Integer = zlib.DEFLATE_ENCODING, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL) As zlib.ZStream
+		 Shared Function Create(OutputStream As Writeable, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Encoding As zlib.Encoding = zlib.Encoding.Deflate, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL) As zlib.ZStream
 		  ' Create a compression stream where compressed output is written to the OutputStream object.
 		  
 		  Return New ZStream(New Deflater(CompressionLevel, CompressionStrategy, Encoding, MemoryLevel), OutputStream)
@@ -100,7 +100,7 @@ Implements zlib.CompressedStream
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function CreatePipe(InputStream As Readable, OutputStream As Writeable, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Encoding As Integer = zlib.DEFLATE_ENCODING, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL) As zlib.ZStream
+		 Shared Function CreatePipe(InputStream As Readable, OutputStream As Writeable, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Encoding As zlib.Encoding = zlib.Encoding.Deflate, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL) As zlib.ZStream
 		  ' Create a compressed stream from two endpoints. Writing to the stream writes compressed bytes to
 		  ' the OutputStream object; reading from the stream decompresses bytes from the InputStream object.
 		  
@@ -192,7 +192,7 @@ Implements zlib.CompressedStream
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function Open(InputStream As FolderItem, Encoding As Integer = zlib.Z_DETECT) As zlib.ZStream
+		 Shared Function Open(InputStream As FolderItem, Encoding As zlib.Encoding = zlib.Encoding.Detect) As zlib.ZStream
 		  ' Create a decompression stream where the compressed input is read from the Source file.
 		  
 		  Return Open(BinaryStream.Open(InputStream), Encoding)
@@ -200,7 +200,7 @@ Implements zlib.CompressedStream
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function Open(InputStream As Readable, Encoding As Integer = zlib.Z_DETECT) As zlib.ZStream
+		 Shared Function Open(InputStream As Readable, Encoding As zlib.Encoding = zlib.Encoding.Detect) As zlib.ZStream
 		  ' Create a decompression stream where the compressed input is read from the InputStream object.
 		  
 		  Return New ZStream(New Inflater(Encoding), InputStream)
@@ -351,11 +351,11 @@ Implements zlib.CompressedStream
 	#tag Method, Flags = &h0
 		Function Sync(MaxCount As Integer = - 1) As Boolean
 		  ' Reads compressed bytes from the input stream until a possible full flush point is detected.
-		  ' If a flush point was found then decompressor switches to RAW_ENCODING, the Position
+		  ' If a flush point was found then decompressor switches to zlib.Encoding.Raw, the Position
 		  ' property of the Source BinaryStream is moved to the flush point, and this method returns True.
 		  
 		  If mInflater = Nil Or Not mSource IsA BinaryStream Then Return False
-		  Dim raw As New zlib.Inflater(RAW_ENCODING)
+		  Dim raw As New zlib.Inflater(zlib.Encoding.Raw)
 		  Dim pos As UInt64 = BinaryStream(mSource).Position
 		  If raw.SyncToNextFlush(mSource, MaxCount) Then
 		    Dim mb As New MemoryBlock(0)
@@ -365,7 +365,7 @@ Implements zlib.CompressedStream
 		    If raw.Inflate(mSource, tmp, 1024) Then
 		      BinaryStream(mSource).Position = flushpos
 		      raw.IgnoreChecksums = True
-		      mInflater.Reset(RAW_ENCODING)
+		      mInflater.Reset(zlib.Encoding.Raw)
 		      mInflater.IgnoreChecksums = True
 		      mReadBuffer = ""
 		      Return True
@@ -462,7 +462,7 @@ Implements zlib.CompressedStream
 			  End If
 			End Get
 		#tag EndGetter
-		Encoding As Integer
+		Encoding As zlib.Encoding
 	#tag EndComputedProperty
 
 	#tag ComputedProperty, Flags = &h0

--- a/zlib/ZStream.rbbas
+++ b/zlib/ZStream.rbbas
@@ -24,14 +24,14 @@ Implements zlib.CompressedStream
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub Constructor(Source As BinaryStream, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Encoding As zlib.Encoding = zlib.Encoding.Detect, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL)
+		Sub Constructor(Source As BinaryStream, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Encoding As zlib.Encoding = zlib.Encoding.Detect, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL)
 		  ' Constructs a ZStream from the Source BinaryStream. If the Source's current position is equal
 		  ' to its length then compressed output will be appended, otherwise the Source will be used as 
 		  ' input to be decompressed.
 		  
 		  If Source.Length = Source.Position Then 'compress into Source
 		    If Encoding = zlib.Encoding.Detect Then Encoding = zlib.Encoding.Deflate
-		    Me.Constructor(New Deflater(CompressionLevel, CompressionStrategy, Encoding, MemoryLevel), Source)
+		    Me.Constructor(New Deflater(CompressionLevel, Encoding, CompressionStrategy, MemoryLevel), Source)
 		  Else ' decompress from Source
 		    If Encoding = zlib.Encoding.Detect Then
 		      Select Case True
@@ -49,13 +49,13 @@ Implements zlib.CompressedStream
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub Constructor(Source As MemoryBlock, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Encoding As zlib.Encoding = zlib.Encoding.Detect, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL)
+		Sub Constructor(Source As MemoryBlock, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Encoding As zlib.Encoding = zlib.Encoding.Detect, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL)
 		  ' Constructs a ZStream from the Source MemoryBlock. If the Source's size is zero then
 		  ' compressed output will be appended, otherwise the Source will be used as input
 		  ' to be decompressed.
 		  
 		  If Source.Size >= 0 Then
-		    Me.Constructor(New BinaryStream(Source), CompressionLevel, CompressionStrategy, Encoding, MemoryLevel)
+		    Me.Constructor(New BinaryStream(Source), CompressionLevel, Encoding, CompressionStrategy, MemoryLevel)
 		  Else
 		    Raise New zlibException(Z_DATA_ERROR) ' can't use memoryblocks of unknown size!!
 		  End If
@@ -83,28 +83,28 @@ Implements zlib.CompressedStream
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function Create(OutputStream As FolderItem, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Overwrite As Boolean = False, Encoding As zlib.Encoding = zlib.Encoding.Deflate, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL) As zlib.ZStream
+		 Shared Function Create(OutputStream As FolderItem, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Encoding As zlib.Encoding = zlib.Encoding.Deflate, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Overwrite As Boolean = False, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL) As zlib.ZStream
 		  ' Create a compression stream where compressed output is written to the OutputStream file.
 		  
-		  Return Create(BinaryStream.Create(OutputStream, Overwrite), CompressionLevel, CompressionStrategy, Encoding, MemoryLevel)
+		  Return Create(BinaryStream.Create(OutputStream, Overwrite), CompressionLevel, Encoding, CompressionStrategy, MemoryLevel)
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function Create(OutputStream As Writeable, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Encoding As zlib.Encoding = zlib.Encoding.Deflate, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL) As zlib.ZStream
+		 Shared Function Create(OutputStream As Writeable, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Encoding As zlib.Encoding = zlib.Encoding.Deflate, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL) As zlib.ZStream
 		  ' Create a compression stream where compressed output is written to the OutputStream object.
 		  
-		  Return New ZStream(New Deflater(CompressionLevel, CompressionStrategy, Encoding, MemoryLevel), OutputStream)
+		  Return New ZStream(New Deflater(CompressionLevel, Encoding, CompressionStrategy, MemoryLevel), OutputStream)
 		  
 		End Function
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		 Shared Function CreatePipe(InputStream As Readable, OutputStream As Writeable, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, Encoding As zlib.Encoding = zlib.Encoding.Deflate, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL) As zlib.ZStream
+		 Shared Function CreatePipe(InputStream As Readable, OutputStream As Writeable, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Encoding As zlib.Encoding = zlib.Encoding.Deflate, CompressionStrategy As zlib.Strategies = zlib.Strategies.Default, MemoryLevel As Integer = zlib.DEFAULT_MEM_LVL) As zlib.ZStream
 		  ' Create a compressed stream from two endpoints. Writing to the stream writes compressed bytes to
 		  ' the OutputStream object; reading from the stream decompresses bytes from the InputStream object.
 		  
-		  Dim z As zlib.ZStream = Create(OutputStream, CompressionLevel, CompressionStrategy, Encoding, MemoryLevel)
+		  Dim z As zlib.ZStream = Create(OutputStream, CompressionLevel, Encoding, CompressionStrategy, MemoryLevel)
 		  If z = Nil Then Return Nil
 		  z.mSource = InputStream
 		  z.mInflater = New Inflater(Encoding)

--- a/zlib/ZStream.rbbas
+++ b/zlib/ZStream.rbbas
@@ -11,7 +11,7 @@ Implements zlib.CompressedStream
 		  
 		  If mDeflater <> Nil Then
 		    Try
-		      Me.Flush(Z_FINISH)
+		      Me.Flush(FlushMode.Finish)
 		    Catch
 		    End Try
 		  End If
@@ -140,12 +140,12 @@ Implements zlib.CompressedStream
 		  ' Flushing may degrade compression so it should be used only when necessary. This completes the
 		  ' current deflate block and follows it with an empty stored block that is three bits plus filler bits
 		  ' to the next byte, followed by four bytes (00 00 ff ff).
-		  Me.Flush(Z_SYNC_FLUSH)
+		  Me.Flush(FlushMode.Sync)
 		End Sub
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
-		Sub Flush(Flushing As Integer)
+		Sub Flush(Flushing As zlib.FlushMode)
 		  // Part of the zlib.CompressedStream interface.
 		  ' Flushing may be:
 		  '   Z_NO_FLUSH:      allows deflate to decide how much data to accumulate before producing output

--- a/zlib/ZipArchive.rbbas
+++ b/zlib/ZipArchive.rbbas
@@ -17,7 +17,7 @@ Protected Class ZipArchive
 		  mArchiveStream = ArchiveStream
 		  mArchiveStream.LittleEndian = True
 		  If Not Me.Reset(0) Then Raise New zlibException(ERR_NOT_ZIPPED)
-		  mZipStream = ZStream.Open(mArchiveStream, RAW_ENCODING)
+		  mZipStream = ZStream.Open(mArchiveStream, zlib.Encoding.Raw)
 		  mZipStream.BufferedReading = False
 		End Sub
 	#tag EndMethod

--- a/zlib/zlib.rbbas
+++ b/zlib/zlib.rbbas
@@ -147,7 +147,7 @@ Protected Module zlib
 	#tag EndExternalMethod
 
 	#tag Method, Flags = &h1
-		Protected Function Deflate(Source As FolderItem, Destination As FolderItem, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Overwrite As Boolean = False, Encoding As Integer = zlib.DEFLATE_ENCODING) As Boolean
+		Protected Function Deflate(Source As FolderItem, Destination As FolderItem, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Overwrite As Boolean = False, Encoding As zlib.Encoding = zlib.Encoding.Deflate) As Boolean
 		  ' Compress the Source file into the Destination file. Use Inflate to reverse.
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.Deflate
 		  
@@ -166,7 +166,7 @@ Protected Module zlib
 	#tag EndMethod
 
 	#tag Method, Flags = &h1
-		Protected Function Deflate(Source As FolderItem, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Encoding As Integer = zlib.DEFLATE_ENCODING) As MemoryBlock
+		Protected Function Deflate(Source As FolderItem, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Encoding As zlib.Encoding = zlib.Encoding.Deflate) As MemoryBlock
 		  ' Compress the Source file and return it. Use Inflate to reverse.
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.Deflate
 		  
@@ -186,7 +186,7 @@ Protected Module zlib
 	#tag EndMethod
 
 	#tag Method, Flags = &h1
-		Protected Function Deflate(Source As FolderItem, Destination As Writeable, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Encoding As Integer = zlib.DEFLATE_ENCODING) As Boolean
+		Protected Function Deflate(Source As FolderItem, Destination As Writeable, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Encoding As zlib.Encoding = zlib.Encoding.Deflate) As Boolean
 		  ' Compress the Source file into the Destination stream. Use Inflate to reverse.
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.Deflate
 		  
@@ -203,7 +203,7 @@ Protected Module zlib
 	#tag EndMethod
 
 	#tag Method, Flags = &h1
-		Protected Function Deflate(Source As MemoryBlock, Destination As FolderItem, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Overwrite As Boolean = False, Encoding As Integer = zlib.DEFLATE_ENCODING) As Boolean
+		Protected Function Deflate(Source As MemoryBlock, Destination As FolderItem, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Overwrite As Boolean = False, Encoding As zlib.Encoding = zlib.Encoding.Deflate) As Boolean
 		  ' Compress the Source data into the Destination file. Use Inflate to reverse.
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.Deflate
 		  
@@ -220,7 +220,7 @@ Protected Module zlib
 	#tag EndMethod
 
 	#tag Method, Flags = &h1
-		Protected Function Deflate(Source As MemoryBlock, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Encoding As Integer = zlib.DEFLATE_ENCODING) As MemoryBlock
+		Protected Function Deflate(Source As MemoryBlock, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Encoding As zlib.Encoding = zlib.Encoding.Deflate) As MemoryBlock
 		  ' Compress the Source data and return it. Use Inflate to reverse.
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.Deflate
 		  
@@ -235,7 +235,7 @@ Protected Module zlib
 	#tag EndMethod
 
 	#tag Method, Flags = &h1
-		Protected Function Deflate(Source As MemoryBlock, Destination As Writeable, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Encoding As Integer = zlib.DEFLATE_ENCODING) As Boolean
+		Protected Function Deflate(Source As MemoryBlock, Destination As Writeable, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Encoding As zlib.Encoding = zlib.Encoding.Deflate) As Boolean
 		  ' Compress the Source data into the Destination stream. Use Inflate to reverse.
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.Deflate
 		  
@@ -246,7 +246,7 @@ Protected Module zlib
 	#tag EndMethod
 
 	#tag Method, Flags = &h1
-		Protected Function Deflate(Source As Readable, Destination As FolderItem, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Overwrite As Boolean = False, Encoding As Integer = zlib.DEFLATE_ENCODING) As Boolean
+		Protected Function Deflate(Source As Readable, Destination As FolderItem, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Overwrite As Boolean = False, Encoding As zlib.Encoding = zlib.Encoding.Deflate) As Boolean
 		  ' Compress the Source stream into the Destination file. Use Inflate to reverse.
 		  
 		  Dim dst As BinaryStream = BinaryStream.Create(Destination, Overwrite)
@@ -262,7 +262,7 @@ Protected Module zlib
 	#tag EndMethod
 
 	#tag Method, Flags = &h1
-		Protected Function Deflate(Source As Readable, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Encoding As Integer = zlib.DEFLATE_ENCODING) As MemoryBlock
+		Protected Function Deflate(Source As Readable, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Encoding As zlib.Encoding = zlib.Encoding.Deflate) As MemoryBlock
 		  ' Compress the Source stream and return it. Use Inflate to reverse.
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.Deflate
 		  
@@ -276,7 +276,7 @@ Protected Module zlib
 	#tag EndMethod
 
 	#tag Method, Flags = &h1
-		Protected Function Deflate(Source As Readable, Destination As Writeable, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Encoding As Integer = zlib.DEFLATE_ENCODING) As Boolean
+		Protected Function Deflate(Source As Readable, Destination As Writeable, CompressionLevel As Integer = zlib.Z_DEFAULT_COMPRESSION, Encoding As zlib.Encoding = zlib.Encoding.Deflate) As Boolean
 		  ' Deflate the Source stream and write the output to the Destination stream. Use Inflate to reverse.
 		  ' Calling this method with the default parameters produces the same output as zlib.Compress. The difference
 		  ' is that the size of the input to this method is not limited by available memory whereas Compress() has less
@@ -309,7 +309,7 @@ Protected Module zlib
 	#tag EndExternalMethod
 
 	#tag ExternalMethod, Flags = &h21
-		Private Soft Declare Function deflateInit2_ Lib zlib1 (ByRef Stream As z_stream, CompressionLevel As Integer, CompressionMethod As Integer, Encoding As Integer, MemLevel As Integer, Strategy As Strategies, Version As CString, StreamSz As Integer) As Integer
+		Private Soft Declare Function deflateInit2_ Lib zlib1 (ByRef Stream As z_stream, CompressionLevel As Integer, CompressionMethod As Integer, Encoding As zlib . Encoding, MemLevel As Integer, Strategy As Strategies, Version As CString, StreamSz As Integer) As Integer
 	#tag EndExternalMethod
 
 	#tag ExternalMethod, Flags = &h21
@@ -371,7 +371,7 @@ Protected Module zlib
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.GUnZip
 		  
 		  ' calls Inflate(FolderItem, MemoryBlock, Integer) As MemoryBlock
-		  Return Inflate(Source, Nil, GZIP_ENCODING)
+		  Return Inflate(Source, Nil, zlib.Encoding.GZip)
 		End Function
 	#tag EndMethod
 
@@ -381,7 +381,7 @@ Protected Module zlib
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.GUnZip
 		  
 		  ' calls Inflate(FolderItem, FolderItem, Boolean, MemoryBlock, Integer) As Boolean
-		  Return Inflate(Source, Destination, Overwrite, Nil, GZIP_ENCODING)
+		  Return Inflate(Source, Destination, Overwrite, Nil, zlib.Encoding.GZip)
 		End Function
 	#tag EndMethod
 
@@ -391,7 +391,7 @@ Protected Module zlib
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.GUnZip
 		  
 		  ' calls Inflate(FolderItem, Writeable, Integer, Integer) As Boolean
-		  Return Inflate(Source, Destination, Nil, GZIP_ENCODING)
+		  Return Inflate(Source, Destination, Nil, zlib.Encoding.GZip)
 		End Function
 	#tag EndMethod
 
@@ -401,7 +401,7 @@ Protected Module zlib
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.GUnZip
 		  
 		  ' calls Inflate(MemoryBlock, MemoryBlock, Integer) As MemoryBlock
-		  Return Inflate(Source, Nil, GZIP_ENCODING)
+		  Return Inflate(Source, Nil, zlib.Encoding.GZip)
 		End Function
 	#tag EndMethod
 
@@ -411,7 +411,7 @@ Protected Module zlib
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.GUnZip
 		  
 		  ' calls Inflate(MemoryBlock, FolderItem, Boolean, MemoryBlock, Integer) As Boolean
-		  Return Inflate(Source, Destination, Overwrite, Nil, GZIP_ENCODING)
+		  Return Inflate(Source, Destination, Overwrite, Nil, zlib.Encoding.GZip)
 		End Function
 	#tag EndMethod
 
@@ -421,7 +421,7 @@ Protected Module zlib
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.GUnZip
 		  
 		  ' calls Inflate(MemoryBlock, Writeable, MemoryBlock, Integer) As Boolean
-		  Return Inflate(Source, Destination, Nil, GZIP_ENCODING)
+		  Return Inflate(Source, Destination, Nil, zlib.Encoding.GZip)
 		End Function
 	#tag EndMethod
 
@@ -431,7 +431,7 @@ Protected Module zlib
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.GUnZip
 		  
 		  ' calls Inflate(Readable, MemoryBlock, Integer) As MemoryBlock
-		  Return Inflate(Source, Nil, GZIP_ENCODING)
+		  Return Inflate(Source, Nil, zlib.Encoding.GZip)
 		End Function
 	#tag EndMethod
 
@@ -441,7 +441,7 @@ Protected Module zlib
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.GUnZip
 		  
 		  ' calls Inflate(Readable, FolderItem, Boolean, MemoryBlock, Integer) As Boolean
-		  Return Inflate(Source, Destination, Overwrite, Nil, GZIP_ENCODING)
+		  Return Inflate(Source, Destination, Overwrite, Nil, zlib.Encoding.GZip)
 		End Function
 	#tag EndMethod
 
@@ -451,7 +451,7 @@ Protected Module zlib
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.GUnZip
 		  
 		  ' calls Inflate(Readable, Writeable, MemoryBlock, Integer) As Boolean
-		  Return Inflate(Source, Destination, Nil, GZIP_ENCODING)
+		  Return Inflate(Source, Destination, Nil, zlib.Encoding.GZip)
 		End Function
 	#tag EndMethod
 
@@ -477,7 +477,7 @@ Protected Module zlib
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.GZip
 		  
 		  ' calls Deflate(FolderItem, FolderItem, Integer, Boolean, Integer) As Boolean
-		  Return Deflate(Source, Destination, CompressionLevel, Overwrite, GZIP_ENCODING)
+		  Return Deflate(Source, Destination, CompressionLevel, Overwrite, zlib.Encoding.GZip)
 		End Function
 	#tag EndMethod
 
@@ -487,7 +487,7 @@ Protected Module zlib
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.GZip
 		  
 		  ' calls Deflate(FolderItem, Integer, Integer) As MemoryBlock
-		  Return Deflate(Source, CompressionLevel, GZIP_ENCODING)
+		  Return Deflate(Source, CompressionLevel, zlib.Encoding.GZip)
 		End Function
 	#tag EndMethod
 
@@ -497,7 +497,7 @@ Protected Module zlib
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.GZip
 		  
 		  ' calls Deflate(FolderItem, Writeable, Integer, Integer) As Boolean
-		  Return Deflate(Source, Destination, CompressionLevel, GZIP_ENCODING)
+		  Return Deflate(Source, Destination, CompressionLevel, zlib.Encoding.GZip)
 		  
 		End Function
 	#tag EndMethod
@@ -508,7 +508,7 @@ Protected Module zlib
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.GZip
 		  
 		  ' calls Deflate(MemoryBlock, FolderItem, Integer, Boolean, Integer) As Boolean
-		  Return Deflate(Source, Destination, CompressionLevel, Overwrite, GZIP_ENCODING)
+		  Return Deflate(Source, Destination, CompressionLevel, Overwrite, zlib.Encoding.GZip)
 		End Function
 	#tag EndMethod
 
@@ -518,7 +518,7 @@ Protected Module zlib
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.GZip
 		  
 		  ' calls Deflate(MemoryBlock, Integer, Integer) As MemoryBlock
-		  Return Deflate(Source, CompressionLevel, GZIP_ENCODING)
+		  Return Deflate(Source, CompressionLevel, zlib.Encoding.GZip)
 		End Function
 	#tag EndMethod
 
@@ -529,7 +529,7 @@ Protected Module zlib
 		  
 		  Dim src As New BinaryStream(Source)
 		  ' calls Deflate(Readable, Writeable, Integer, Integer) As Boolean
-		  Return Deflate(src, Destination, CompressionLevel, GZIP_ENCODING)
+		  Return Deflate(src, Destination, CompressionLevel, zlib.Encoding.GZip)
 		End Function
 	#tag EndMethod
 
@@ -539,7 +539,7 @@ Protected Module zlib
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.GZip
 		  
 		  ' calls Deflate(Readable, FolderItem, Integer, Boolean, Integer) As Boolean
-		  Return Deflate(Source, Destination, CompressionLevel, Overwrite, GZIP_ENCODING)
+		  Return Deflate(Source, Destination, CompressionLevel, Overwrite, zlib.Encoding.GZip)
 		End Function
 	#tag EndMethod
 
@@ -549,7 +549,7 @@ Protected Module zlib
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.GZip
 		  
 		  ' calls Deflate(Readable, Integer, Integer) As MemoryBlock
-		  Return Deflate(Source, CompressionLevel, GZIP_ENCODING)
+		  Return Deflate(Source, CompressionLevel, zlib.Encoding.GZip)
 		End Function
 	#tag EndMethod
 
@@ -559,7 +559,7 @@ Protected Module zlib
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.GZip
 		  
 		  ' calls Deflate(Readable, Writeable, Integer, Integer) As Boolean
-		  Return Deflate(Source, Destination, CompressionLevel, GZIP_ENCODING)
+		  Return Deflate(Source, Destination, CompressionLevel, zlib.Encoding.GZip)
 		End Function
 	#tag EndMethod
 
@@ -592,7 +592,7 @@ Protected Module zlib
 	#tag EndExternalMethod
 
 	#tag Method, Flags = &h1
-		Protected Function Inflate(Source As FolderItem, Destination As FolderItem, Overwrite As Boolean = False, Dictionary As MemoryBlock = Nil, Encoding As Integer = zlib.DEFLATE_ENCODING) As Boolean
+		Protected Function Inflate(Source As FolderItem, Destination As FolderItem, Overwrite As Boolean = False, Dictionary As MemoryBlock = Nil, Encoding As zlib.Encoding = zlib.Encoding.Deflate) As Boolean
 		  ' Decompress the Source file and write the output to the Destination file. Reverses the Deflate method
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.Inflate
 		  
@@ -611,7 +611,7 @@ Protected Module zlib
 	#tag EndMethod
 
 	#tag Method, Flags = &h1
-		Protected Function Inflate(Source As FolderItem, Dictionary As MemoryBlock = Nil, Encoding As Integer = zlib.DEFLATE_ENCODING) As MemoryBlock
+		Protected Function Inflate(Source As FolderItem, Dictionary As MemoryBlock = Nil, Encoding As zlib.Encoding = zlib.Encoding.Deflate) As MemoryBlock
 		  ' Decompress the Source file and return it. Reverses the Deflate method
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.Inflate
 		  
@@ -631,7 +631,7 @@ Protected Module zlib
 	#tag EndMethod
 
 	#tag Method, Flags = &h1
-		Protected Function Inflate(Source As FolderItem, Destination As Writeable, Dictionary As MemoryBlock = Nil, Encoding As Integer = zlib.DEFLATE_ENCODING) As Boolean
+		Protected Function Inflate(Source As FolderItem, Destination As Writeable, Dictionary As MemoryBlock = Nil, Encoding As zlib.Encoding = zlib.Encoding.Deflate) As Boolean
 		  ' Decompresses the Source file into the Destination stream. Reverses the Deflate method
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.Inflate
 		  
@@ -648,7 +648,7 @@ Protected Module zlib
 	#tag EndMethod
 
 	#tag Method, Flags = &h1
-		Protected Function Inflate(Source As MemoryBlock, Destination As FolderItem, Overwrite As Boolean = False, Dictionary As MemoryBlock = Nil, Encoding As Integer = zlib.DEFLATE_ENCODING) As Boolean
+		Protected Function Inflate(Source As MemoryBlock, Destination As FolderItem, Overwrite As Boolean = False, Dictionary As MemoryBlock = Nil, Encoding As zlib.Encoding = zlib.Encoding.Deflate) As Boolean
 		  ' Decompress the Source data into the Destination file. Reverses the Deflate method
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.Inflate
 		  
@@ -667,7 +667,7 @@ Protected Module zlib
 	#tag EndMethod
 
 	#tag Method, Flags = &h1
-		Protected Function Inflate(Source As MemoryBlock, Dictionary As MemoryBlock = Nil, Encoding As Integer = zlib.DEFLATE_ENCODING) As MemoryBlock
+		Protected Function Inflate(Source As MemoryBlock, Dictionary As MemoryBlock = Nil, Encoding As zlib.Encoding = zlib.Encoding.Deflate) As MemoryBlock
 		  ' Decompress the Source data and return it. Reverses the Deflate method
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.Inflate
 		  
@@ -678,7 +678,7 @@ Protected Module zlib
 	#tag EndMethod
 
 	#tag Method, Flags = &h1
-		Protected Function Inflate(Source As MemoryBlock, Destination As Writeable, Dictionary As MemoryBlock = Nil, Encoding As Integer = zlib.DEFLATE_ENCODING) As Boolean
+		Protected Function Inflate(Source As MemoryBlock, Destination As Writeable, Dictionary As MemoryBlock = Nil, Encoding As zlib.Encoding = zlib.Encoding.Deflate) As Boolean
 		  ' Decompress the Source data into the Destination stream. Reverses the Deflate method
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.Inflate
 		  
@@ -695,7 +695,7 @@ Protected Module zlib
 	#tag EndMethod
 
 	#tag Method, Flags = &h1
-		Protected Function Inflate(Source As Readable, Destination As FolderItem, Overwrite As Boolean = False, Dictionary As MemoryBlock = Nil, Encoding As Integer = zlib.DEFLATE_ENCODING) As Boolean
+		Protected Function Inflate(Source As Readable, Destination As FolderItem, Overwrite As Boolean = False, Dictionary As MemoryBlock = Nil, Encoding As zlib.Encoding = zlib.Encoding.Deflate) As Boolean
 		  ' Decompress the Source stream into the Destination file. Reverses the Deflate method
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.Inflate
 		  
@@ -712,7 +712,7 @@ Protected Module zlib
 	#tag EndMethod
 
 	#tag Method, Flags = &h1
-		Protected Function Inflate(Source As Readable, Dictionary As MemoryBlock = Nil, Encoding As Integer = zlib.DEFLATE_ENCODING) As MemoryBlock
+		Protected Function Inflate(Source As Readable, Dictionary As MemoryBlock = Nil, Encoding As zlib.Encoding = zlib.Encoding.Deflate) As MemoryBlock
 		  ' Decompress the Source stream and return it. Reverses the Deflate method
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.Inflate
 		  
@@ -726,7 +726,7 @@ Protected Module zlib
 	#tag EndMethod
 
 	#tag Method, Flags = &h1
-		Protected Function Inflate(Source As Readable, Destination As Writeable, Dictionary As MemoryBlock = Nil, Encoding As Integer = zlib.DEFLATE_ENCODING) As Boolean
+		Protected Function Inflate(Source As Readable, Destination As Writeable, Dictionary As MemoryBlock = Nil, Encoding As zlib.Encoding = zlib.Encoding.Deflate) As Boolean
 		  ' Decompress the Source stream and write the output to the Destination stream. Reverses the Deflate method
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.Inflate
 		  
@@ -763,7 +763,7 @@ Protected Module zlib
 	#tag EndExternalMethod
 
 	#tag ExternalMethod, Flags = &h21
-		Private Soft Declare Function inflateInit2_ Lib zlib1 (ByRef Stream As z_stream, Encoding As Integer, Version As CString, StreamSz As Integer) As Integer
+		Private Soft Declare Function inflateInit2_ Lib zlib1 (ByRef Stream As z_stream, Encoding As zlib . Encoding, Version As CString, StreamSz As Integer) As Integer
 	#tag EndExternalMethod
 
 	#tag ExternalMethod, Flags = &h21
@@ -779,7 +779,7 @@ Protected Module zlib
 	#tag EndExternalMethod
 
 	#tag ExternalMethod, Flags = &h21
-		Private Soft Declare Function inflateReset2 Lib zlib1 (ByRef Stream As z_stream, Encoding As Integer) As Integer
+		Private Soft Declare Function inflateReset2 Lib zlib1 (ByRef Stream As z_stream, Encoding As zlib . Encoding) As Integer
 	#tag EndExternalMethod
 
 	#tag ExternalMethod, Flags = &h21
@@ -1150,7 +1150,7 @@ Protected Module zlib
 	#tag Constant, Name = DEFAULT_MEM_LVL, Type = Double, Dynamic = False, Default = \"8", Scope = Protected
 	#tag EndConstant
 
-	#tag Constant, Name = DEFLATE_ENCODING, Type = Double, Dynamic = False, Default = \"15", Scope = Protected
+	#tag Constant, Name = DEFLATE_ENCODING, Type = Double, Dynamic = False, Default = \"15", Scope = Protected, Attributes = \"deprecated \x3D "Encoding.Deflate""
 	#tag EndConstant
 
 	#tag Constant, Name = ERR_CHECKSUM_MISMATCH, Type = Double, Dynamic = False, Default = \"-204", Scope = Protected
@@ -1171,10 +1171,10 @@ Protected Module zlib
 	#tag Constant, Name = ERR_UNSUPPORTED_COMPRESSION, Type = Double, Dynamic = False, Default = \"-203", Scope = Protected
 	#tag EndConstant
 
-	#tag Constant, Name = GZIP_ENCODING, Type = Double, Dynamic = False, Default = \"31", Scope = Protected
+	#tag Constant, Name = GZIP_ENCODING, Type = Double, Dynamic = False, Default = \"31", Scope = Protected, Attributes = \"deprecated \x3D "Encoding.GZip""
 	#tag EndConstant
 
-	#tag Constant, Name = RAW_ENCODING, Type = Double, Dynamic = False, Default = \"-15", Scope = Protected
+	#tag Constant, Name = RAW_ENCODING, Type = Double, Dynamic = False, Default = \"-15", Scope = Protected, Attributes = \"deprecated \x3D "Encoding.Raw""
 	#tag EndConstant
 
 	#tag Constant, Name = zlib1, Type = String, Dynamic = False, Default = \"libz.so.1", Scope = Private
@@ -1213,7 +1213,7 @@ Protected Module zlib
 	#tag Constant, Name = Z_DEFLATED, Type = Double, Dynamic = False, Default = \"8", Scope = Private
 	#tag EndConstant
 
-	#tag Constant, Name = Z_DETECT, Type = Double, Dynamic = False, Default = \"47", Scope = Protected
+	#tag Constant, Name = Z_DETECT, Type = Double, Dynamic = False, Default = \"47", Scope = Protected, Attributes = \"deprecated \x3D "Encoding.Detect""
 	#tag EndConstant
 
 	#tag Constant, Name = Z_ERRNO, Type = Double, Dynamic = False, Default = \"-1", Scope = Private
@@ -1379,6 +1379,13 @@ Protected Module zlib
 		  Text=1
 		  ASCII=1
 		Unknown=2
+	#tag EndEnum
+
+	#tag Enum, Name = Encoding, Type = Integer, Flags = &h1
+		Deflate=15
+		  GZip=31
+		  Raw=-15
+		Detect=47
 	#tag EndEnum
 
 	#tag Enum, Name = FlushMode, Type = Integer, Flags = &h1

--- a/zlib/zlib.rbbas
+++ b/zlib/zlib.rbbas
@@ -283,7 +283,7 @@ Protected Module zlib
 		  ' memory overhead.
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.Deflate
 		  
-		  Dim z As ZStream = ZStream.Create(Destination, CompressionLevel, Z_DEFAULT_STRATEGY, Encoding)
+		  Dim z As ZStream = ZStream.Create(Destination, CompressionLevel, Strategies.Default, Encoding)
 		  Try
 		    Do Until Source.EOF
 		      z.Write(Source.Read(CHUNK_SIZE))
@@ -309,7 +309,7 @@ Protected Module zlib
 	#tag EndExternalMethod
 
 	#tag ExternalMethod, Flags = &h21
-		Private Soft Declare Function deflateInit2_ Lib zlib1 (ByRef Stream As z_stream, CompressionLevel As Integer, CompressionMethod As Integer, Encoding As Integer, MemLevel As Integer, Strategy As Integer, Version As CString, StreamSz As Integer) As Integer
+		Private Soft Declare Function deflateInit2_ Lib zlib1 (ByRef Stream As z_stream, CompressionLevel As Integer, CompressionMethod As Integer, Encoding As Integer, MemLevel As Integer, Strategy As Strategies, Version As CString, StreamSz As Integer) As Integer
 	#tag EndExternalMethod
 
 	#tag ExternalMethod, Flags = &h21
@@ -317,7 +317,7 @@ Protected Module zlib
 	#tag EndExternalMethod
 
 	#tag ExternalMethod, Flags = &h21
-		Private Soft Declare Function deflateParams Lib zlib1 (ByRef Stream As z_stream, Level As Integer, Strategy As Integer) As Integer
+		Private Soft Declare Function deflateParams Lib zlib1 (ByRef Stream As z_stream, Level As Integer, Strategy As Strategies) As Integer
 	#tag EndExternalMethod
 
 	#tag ExternalMethod, Flags = &h21
@@ -580,7 +580,7 @@ Protected Module zlib
 	#tag EndExternalMethod
 
 	#tag ExternalMethod, Flags = &h21
-		Private Soft Declare Function gzsetparams Lib zlib1 (gzFile As Ptr, Level As Integer, Strategy As Integer) As Integer
+		Private Soft Declare Function gzsetparams Lib zlib1 (gzFile As Ptr, Level As Integer, Strategy As Strategies) As Integer
 	#tag EndExternalMethod
 
 	#tag ExternalMethod, Flags = &h21
@@ -1207,7 +1207,7 @@ Protected Module zlib
 	#tag Constant, Name = Z_DEFAULT_COMPRESSION, Type = Double, Dynamic = False, Default = \"-1", Scope = Protected
 	#tag EndConstant
 
-	#tag Constant, Name = Z_DEFAULT_STRATEGY, Type = Double, Dynamic = False, Default = \"0", Scope = Protected
+	#tag Constant, Name = Z_DEFAULT_STRATEGY, Type = Double, Dynamic = False, Default = \"0", Scope = Protected, Attributes = \"deprecated \x3D "Strategies.Default""
 	#tag EndConstant
 
 	#tag Constant, Name = Z_DEFLATED, Type = Double, Dynamic = False, Default = \"8", Scope = Protected
@@ -1219,19 +1219,19 @@ Protected Module zlib
 	#tag Constant, Name = Z_ERRNO, Type = Double, Dynamic = False, Default = \"-1", Scope = Private
 	#tag EndConstant
 
-	#tag Constant, Name = Z_FILTERED, Type = Double, Dynamic = False, Default = \"1", Scope = Protected
+	#tag Constant, Name = Z_FILTERED, Type = Double, Dynamic = False, Default = \"1", Scope = Protected, Attributes = \"deprecated \x3D "Strategies.Filtered""
 	#tag EndConstant
 
 	#tag Constant, Name = Z_FINISH, Type = Double, Dynamic = False, Default = \"4", Scope = Protected, Attributes = \"deprecated \x3D "FlushMode.Finish""
 	#tag EndConstant
 
-	#tag Constant, Name = Z_FIXED, Type = Double, Dynamic = False, Default = \"4", Scope = Protected
+	#tag Constant, Name = Z_FIXED, Type = Double, Dynamic = False, Default = \"4", Scope = Protected, Attributes = \"deprecated \x3D "Strategies.Fixed""
 	#tag EndConstant
 
 	#tag Constant, Name = Z_FULL_FLUSH, Type = Double, Dynamic = False, Default = \"3", Scope = Protected, Attributes = \"deprecated \x3D "FlushMode.Full""
 	#tag EndConstant
 
-	#tag Constant, Name = Z_HUFFMAN_ONLY, Type = Double, Dynamic = False, Default = \"2", Scope = Protected
+	#tag Constant, Name = Z_HUFFMAN_ONLY, Type = Double, Dynamic = False, Default = \"2", Scope = Protected, Attributes = \"deprecated \x3D "Strategies.HuffmanOnly""
 	#tag EndConstant
 
 	#tag Constant, Name = Z_MEM_ERROR, Type = Double, Dynamic = False, Default = \"-4", Scope = Private
@@ -1252,7 +1252,7 @@ Protected Module zlib
 	#tag Constant, Name = Z_PARTIAL_FLUSH, Type = Double, Dynamic = False, Default = \"1", Scope = Protected, Attributes = \"deprecated \x3D "FlushMode.Partial""
 	#tag EndConstant
 
-	#tag Constant, Name = Z_RLE, Type = Double, Dynamic = False, Default = \"3", Scope = Protected
+	#tag Constant, Name = Z_RLE, Type = Double, Dynamic = False, Default = \"3", Scope = Protected, Attributes = \"deprecated \x3D "Strategies.RLE""
 	#tag EndConstant
 
 	#tag Constant, Name = Z_STREAM_END, Type = Double, Dynamic = False, Default = \"1", Scope = Private
@@ -1383,6 +1383,15 @@ Protected Module zlib
 		  Block=5
 		Trees=6
 	#tag EndEnum
+
+	#tag Enum, Name = Strategies, Type = Integer, Flags = &h1
+		Default=0
+		  Filtered=1
+		  HuffmanOnly=2
+		  RLE=3
+		Fixed=4
+	#tag EndEnum
+
 
 	#tag ViewBehavior
 		#tag ViewProperty

--- a/zlib/zlib.rbbas
+++ b/zlib/zlib.rbbas
@@ -1210,7 +1210,7 @@ Protected Module zlib
 	#tag Constant, Name = Z_DEFAULT_STRATEGY, Type = Double, Dynamic = False, Default = \"0", Scope = Protected, Attributes = \"deprecated \x3D "Strategies.Default""
 	#tag EndConstant
 
-	#tag Constant, Name = Z_DEFLATED, Type = Double, Dynamic = False, Default = \"8", Scope = Protected
+	#tag Constant, Name = Z_DEFLATED, Type = Double, Dynamic = False, Default = \"8", Scope = Private
 	#tag EndConstant
 
 	#tag Constant, Name = Z_DETECT, Type = Double, Dynamic = False, Default = \"47", Scope = Protected

--- a/zlib/zlib.rbbas
+++ b/zlib/zlib.rbbas
@@ -1183,7 +1183,7 @@ Protected Module zlib
 		#Tag Instance, Platform = Linux, Language = Default, Definition  = \"libz.so.1"
 	#tag EndConstant
 
-	#tag Constant, Name = Z_ASCII, Type = Double, Dynamic = False, Default = \"Z_TEXT", Scope = Protected
+	#tag Constant, Name = Z_ASCII, Type = Double, Dynamic = False, Default = \"1", Scope = Protected, Attributes = \"deprecated \x3D "DataType.ASCII""
 	#tag EndConstant
 
 	#tag Constant, Name = Z_BEST_COMPRESSION, Type = Double, Dynamic = False, Default = \"9", Scope = Protected
@@ -1192,7 +1192,7 @@ Protected Module zlib
 	#tag Constant, Name = Z_BEST_SPEED, Type = Double, Dynamic = False, Default = \"1", Scope = Protected
 	#tag EndConstant
 
-	#tag Constant, Name = Z_BINARY, Type = Double, Dynamic = False, Default = \"0", Scope = Protected
+	#tag Constant, Name = Z_BINARY, Type = Double, Dynamic = False, Default = \"0", Scope = Protected, Attributes = \"deprecated \x3D "DataType.Binary""
 	#tag EndConstant
 
 	#tag Constant, Name = Z_BLOCK, Type = Double, Dynamic = False, Default = \"5", Scope = Protected, Attributes = \"deprecated \x3D "FlushMode.Block""
@@ -1264,13 +1264,13 @@ Protected Module zlib
 	#tag Constant, Name = Z_SYNC_FLUSH, Type = Double, Dynamic = False, Default = \"2", Scope = Protected, Attributes = \"deprecated \x3D "FlushMode.Sync""
 	#tag EndConstant
 
-	#tag Constant, Name = Z_TEXT, Type = Double, Dynamic = False, Default = \"1", Scope = Protected
+	#tag Constant, Name = Z_TEXT, Type = Double, Dynamic = False, Default = \"1", Scope = Protected, Attributes = \"deprecated \x3D "DataType.Text""
 	#tag EndConstant
 
 	#tag Constant, Name = Z_TREES, Type = Double, Dynamic = False, Default = \"6", Scope = Protected, Attributes = \"deprecated \x3D "FlushMode.Trees""
 	#tag EndConstant
 
-	#tag Constant, Name = Z_UNKNOWN, Type = Double, Dynamic = False, Default = \"2", Scope = Protected
+	#tag Constant, Name = Z_UNKNOWN, Type = Double, Dynamic = False, Default = \"2", Scope = Protected, Attributes = \"deprecated \x3D "DataType.Unknown""
 	#tag EndConstant
 
 	#tag Constant, Name = Z_VERSION_ERROR, Type = Double, Dynamic = False, Default = \"-6", Scope = Private
@@ -1372,6 +1372,13 @@ Protected Module zlib
 		  Directory
 		  FIFO
 		Contiguous
+	#tag EndEnum
+
+	#tag Enum, Name = DataType, Type = Integer, Flags = &h1
+		Binary=0
+		  Text=1
+		  ASCII=1
+		Unknown=2
 	#tag EndEnum
 
 	#tag Enum, Name = FlushMode, Type = Integer, Flags = &h1

--- a/zlib/zlib.rbbas
+++ b/zlib/zlib.rbbas
@@ -283,7 +283,7 @@ Protected Module zlib
 		  ' memory overhead.
 		  ' See: https://github.com/charonn0/RB-zlib/wiki/zlib.Deflate
 		  
-		  Dim z As ZStream = ZStream.Create(Destination, CompressionLevel, Strategies.Default, Encoding)
+		  Dim z As ZStream = ZStream.Create(Destination, CompressionLevel, Encoding)
 		  Try
 		    Do Until Source.EOF
 		      z.Write(Source.Read(CHUNK_SIZE))

--- a/zlib/zlib.rbbas
+++ b/zlib/zlib.rbbas
@@ -143,7 +143,7 @@ Protected Module zlib
 	#tag EndMethod
 
 	#tag ExternalMethod, Flags = &h21
-		Private Soft Declare Function deflate Lib zlib1 (ByRef Stream As z_stream, Flush As Integer) As Integer
+		Private Soft Declare Function deflate Lib zlib1 (ByRef Stream As z_stream, Flush As FlushMode) As Integer
 	#tag EndExternalMethod
 
 	#tag Method, Flags = &h1
@@ -468,7 +468,7 @@ Protected Module zlib
 	#tag EndExternalMethod
 
 	#tag ExternalMethod, Flags = &h21
-		Private Soft Declare Function gzflush Lib zlib1 (gzFile As Ptr, Flush As Integer) As Integer
+		Private Soft Declare Function gzflush Lib zlib1 (gzFile As Ptr, Flush As FlushMode) As Integer
 	#tag EndExternalMethod
 
 	#tag Method, Flags = &h1
@@ -588,7 +588,7 @@ Protected Module zlib
 	#tag EndExternalMethod
 
 	#tag ExternalMethod, Flags = &h21
-		Private Soft Declare Function inflate Lib zlib1 (ByRef Stream As z_stream, Flush As Integer) As Integer
+		Private Soft Declare Function inflate Lib zlib1 (ByRef Stream As z_stream, Flush As FlushMode) As Integer
 	#tag EndExternalMethod
 
 	#tag Method, Flags = &h1
@@ -1195,7 +1195,7 @@ Protected Module zlib
 	#tag Constant, Name = Z_BINARY, Type = Double, Dynamic = False, Default = \"0", Scope = Protected
 	#tag EndConstant
 
-	#tag Constant, Name = Z_BLOCK, Type = Double, Dynamic = False, Default = \"5", Scope = Protected
+	#tag Constant, Name = Z_BLOCK, Type = Double, Dynamic = False, Default = \"5", Scope = Protected, Attributes = \"deprecated \x3D "FlushMode.Block""
 	#tag EndConstant
 
 	#tag Constant, Name = Z_BUF_ERROR, Type = Double, Dynamic = False, Default = \"-5", Scope = Private
@@ -1222,13 +1222,13 @@ Protected Module zlib
 	#tag Constant, Name = Z_FILTERED, Type = Double, Dynamic = False, Default = \"1", Scope = Protected
 	#tag EndConstant
 
-	#tag Constant, Name = Z_FINISH, Type = Double, Dynamic = False, Default = \"4", Scope = Protected
+	#tag Constant, Name = Z_FINISH, Type = Double, Dynamic = False, Default = \"4", Scope = Protected, Attributes = \"deprecated \x3D "FlushMode.Finish""
 	#tag EndConstant
 
 	#tag Constant, Name = Z_FIXED, Type = Double, Dynamic = False, Default = \"4", Scope = Protected
 	#tag EndConstant
 
-	#tag Constant, Name = Z_FULL_FLUSH, Type = Double, Dynamic = False, Default = \"3", Scope = Protected
+	#tag Constant, Name = Z_FULL_FLUSH, Type = Double, Dynamic = False, Default = \"3", Scope = Protected, Attributes = \"deprecated \x3D "FlushMode.Full""
 	#tag EndConstant
 
 	#tag Constant, Name = Z_HUFFMAN_ONLY, Type = Double, Dynamic = False, Default = \"2", Scope = Protected
@@ -1243,13 +1243,13 @@ Protected Module zlib
 	#tag Constant, Name = Z_NO_COMPRESSION, Type = Double, Dynamic = False, Default = \"0", Scope = Protected
 	#tag EndConstant
 
-	#tag Constant, Name = Z_NO_FLUSH, Type = Double, Dynamic = False, Default = \"0", Scope = Protected
+	#tag Constant, Name = Z_NO_FLUSH, Type = Double, Dynamic = False, Default = \"0", Scope = Protected, Attributes = \"deprecated \x3D "FlushMode.None""
 	#tag EndConstant
 
 	#tag Constant, Name = Z_OK, Type = Double, Dynamic = False, Default = \"0", Scope = Private
 	#tag EndConstant
 
-	#tag Constant, Name = Z_PARTIAL_FLUSH, Type = Double, Dynamic = False, Default = \"1", Scope = Protected
+	#tag Constant, Name = Z_PARTIAL_FLUSH, Type = Double, Dynamic = False, Default = \"1", Scope = Protected, Attributes = \"deprecated \x3D "FlushMode.Partial""
 	#tag EndConstant
 
 	#tag Constant, Name = Z_RLE, Type = Double, Dynamic = False, Default = \"3", Scope = Protected
@@ -1261,13 +1261,13 @@ Protected Module zlib
 	#tag Constant, Name = Z_STREAM_ERROR, Type = Double, Dynamic = False, Default = \"-2", Scope = Private
 	#tag EndConstant
 
-	#tag Constant, Name = Z_SYNC_FLUSH, Type = Double, Dynamic = False, Default = \"2", Scope = Protected
+	#tag Constant, Name = Z_SYNC_FLUSH, Type = Double, Dynamic = False, Default = \"2", Scope = Protected, Attributes = \"deprecated \x3D "FlushMode.Sync""
 	#tag EndConstant
 
 	#tag Constant, Name = Z_TEXT, Type = Double, Dynamic = False, Default = \"1", Scope = Protected
 	#tag EndConstant
 
-	#tag Constant, Name = Z_TREES, Type = Double, Dynamic = False, Default = \"6", Scope = Protected
+	#tag Constant, Name = Z_TREES, Type = Double, Dynamic = False, Default = \"6", Scope = Protected, Attributes = \"deprecated \x3D "FlushMode.Trees""
 	#tag EndConstant
 
 	#tag Constant, Name = Z_UNKNOWN, Type = Double, Dynamic = False, Default = \"2", Scope = Protected
@@ -1374,6 +1374,15 @@ Protected Module zlib
 		Contiguous
 	#tag EndEnum
 
+	#tag Enum, Name = FlushMode, Type = Integer, Flags = &h1
+		None=0
+		  Partial=1
+		  Sync=2
+		  Full=3
+		  Finish=4
+		  Block=5
+		Trees=6
+	#tag EndEnum
 
 	#tag ViewBehavior
 		#tag ViewProperty


### PR DESCRIPTION
This PR replaces the various constants defined by zlib into enumerations. This clarifies the purpose of these values by organizing related constants together. This also allows us to rearrange the order in which these are used (e.g. in ZStream.Create). 

This PR reorganizes them so that the `Encoding` can be specified without also specifying the strategy. As such, this introduces a number of breaking changes.